### PR TITLE
Add validUntil to MediatedRefresh2021.

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,9 +363,10 @@ steps:
 
       <ol>
         <li>
-The <a>holder</a> software extracts the `refreshService.type`,
-`refreshService.url`, and `refreshService.validAfter` properties and saves
-them as <em>type</em>, <em>url</em>, and <em>validAfter</em>, respectively.
+The <a>holder</a> software extracts the `refreshService.type`, 
+`refreshService.url`, `refreshService.validAfter`, and
+`refreshService.validUntil` properties and saves
+them as <em>type</em>, <em>url</em>, <em>validAfter</em>, and <em>validUntil</em>, respectively.
         </li>
         <li>
 If <em>type</em> does not equal `MediatedRefresh2021`,
@@ -374,6 +375,10 @@ raise an `INVALID_REFRESH_ALGORITHM` exception.
         <li>
 If <em>validAfter</em> is defined, but expresses a datetime that is later
 than the current datetime, raise a `REFRESH_NOT_ALLOWED` exception.
+        </li>
+        <li>
+If <em>validUntil</em> is defined, but expresses a datetime that is before
+the current datetime, raise a `REFRESH_NOT_ALLOWED` exception.
         </li>
         <li>
 If <em>url</em> is not defined, raise an `INVALID_URL` exception.
@@ -411,7 +416,7 @@ consists of executing the following steps:
 
       <ol>
         <li>
-The <a>holder</a> software extracts the `refreshService.type`,
+The <a>holder</a> software extracts the `refreshService.type`, 
 `refreshService.url`, `refreshService.validAfter`, and
 `refreshService.validUntil` properties and saves them as <em>type</em>,
 <em>url</em>, <em>validAfter</em>,  and <em>validUntil</em>, respectively.


### PR DESCRIPTION
Add a `validUntil` step to `MediatedRefresh2021` and also adds spaces to the holder's algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/vc-refresh-2021/pull/4.html" title="Last updated on May 30, 2022, 8:20 PM UTC (c8bffe6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-refresh-2021/4/eeeea65...aljones15:c8bffe6.html" title="Last updated on May 30, 2022, 8:20 PM UTC (c8bffe6)">Diff</a>